### PR TITLE
Consume PR_NUMBER env variable as input

### DIFF
--- a/diff.sh
+++ b/diff.sh
@@ -2,15 +2,14 @@
 
 set -e
 
-PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
-
-if [[ "$PR_NUMBER" == "null" ]]; then
-  PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
-fi
-
-if [[ "$PR_NUMBER" == "null" ]]; then
-  echo "Failed to determine PR Number."
-  exit 1
+# Use environment variable if available, otherwise extract from GitHub event
+if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
+  PR_NUMBER=$(jq -r ".pull_request.number // .issue.number // empty" "$GITHUB_EVENT_PATH")
+  
+  if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
+    echo "Failed to determine PR Number."
+    exit 1
+  fi
 fi
 
 echo "Collecting information about PR #$PR_NUMBER of $GITHUB_REPOSITORY..."


### PR DESCRIPTION
Consume PR_NUMBER env variable as input

context - this is being done to support running this check inside GitHub merge-queue